### PR TITLE
fix compilation error mbedtls_base64_encode not defined

### DIFF
--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -42,8 +42,10 @@
 #include <mbedtls/version.h>
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-#ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+#if defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
 #include <mbedtls/base64.h>
+#endif
+#ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 #include <mbedtls/x509.h>
 #include <mbedtls/x509_crl.h>
 #include <mbedtls/x509_crt.h>


### PR DESCRIPTION
Fix compilation error mbedtls_base64_encode not defined when compiling with MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED disabled.

The logic for including the mbedtls/base64.h header file is doing the wrong define check.