### PR TITLE
[nrf fromtree] [dns-client] fix handling of IPv4 resolve failure (#10766)

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -1572,7 +1572,7 @@ Error Client::ReplaceWithIp4Query(Query &aQuery)
 
     info.ReadFrom(aQuery);
 
-    VerifyOrExit(info.mQueryType == kIp4AddressQuery);
+    VerifyOrExit(info.mQueryType == kIp6AddressQuery);
     VerifyOrExit(info.mConfig.GetNat64Mode() == QueryConfig::kNat64Allow);
 
     // We send a new query for IPv4 address resolution


### PR DESCRIPTION
This commit fixes an issue in `Client::ReplaceWithIp4Query()` where an IPv6 address resolution query failure could lead to an incorrect IPv4 query being sent. The incorrect query type was being checked in this method, causing `ResolveIp4Address()` to keep sending queries.

(cherry picked from commit 4c45ee8e0e550e4ff78e0799f86d9a38bfadbd28)