### PR TITLE
[nrf fromtree] [cli] add '-x' flag to tcp client to send hexadecimal …

### DIFF
--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -461,29 +461,52 @@ exit:
  * tcp send hello
  * Done
  * @endcode
- * @cparam tcp send @ca{message}
+ * @code
+ * tcp send -x 68656c6c6f
+ * Done
+ * @endcode
+ * @cparam tcp send [@ca{type}] @ca{message}
  * The `message` parameter contains the message you want to send to the
  * remote TCP endpoint.
+ * If `type` is `-x`, then
+ * binary data in hexadecimal representation is given in the `message` parameter.
  * @par
  * Sends data over the TCP connection associated with the example TCP endpoint
  * that is provided with the `tcp` CLI. @moreinfo{@tcp}.
  */
 template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
 {
-    otError error;
+    static constexpr uint16_t kBufferSizeForHexData = 128;
+
+    otError  error;
+    uint16_t dataLen;
+    uint8_t *data;
+    uint8_t  buf[kBufferSizeForHexData];
 
     VerifyOrExit(mInitialized, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mBenchmarkBytesTotal == 0, error = OT_ERROR_BUSY);
     VerifyOrExit(!aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+
+    if (aArgs[0] == "-x" && !aArgs[1].IsEmpty())
+    {
+        // Binary hex data payload
+        dataLen = sizeof(buf);
+        data    = &buf[0];
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(dataLen, buf));
+    }
+    else
+    {
+        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        dataLen = aArgs[0].GetLength();
+        data    = reinterpret_cast<uint8_t *>(aArgs[0].GetCString());
+    }
 
     if (mUseCircularSendBuffer)
     {
 #if OPENTHREAD_CONFIG_TLS_ENABLE
         if (mUseTls)
         {
-            int rv = mbedtls_ssl_write(&mSslContext, reinterpret_cast<unsigned char *>(aArgs[0].GetCString()),
-                                       aArgs[0].GetLength());
+            int rv = mbedtls_ssl_write(&mSslContext, data, dataLen);
 
             if (rv < 0 && rv != MBEDTLS_ERR_SSL_WANT_WRITE && rv != MBEDTLS_ERR_SSL_WANT_READ)
             {
@@ -497,8 +520,7 @@ template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
         {
             size_t written;
 
-            SuccessOrExit(error = otTcpCircularSendBufferWrite(&mEndpoint, &mSendBuffer, aArgs[0].GetCString(),
-                                                               aArgs[0].GetLength(), &written, 0));
+            SuccessOrExit(error = otTcpCircularSendBufferWrite(&mEndpoint, &mSendBuffer, data, dataLen, &written, 0));
         }
     }
     else
@@ -507,8 +529,8 @@ template <> otError TcpExample::Process<Cmd("send")>(Arg aArgs[])
 
         mSendLink.mNext   = nullptr;
         mSendLink.mData   = mSendBufferBytes;
-        mSendLink.mLength = OT_MIN(aArgs[0].GetLength(), sizeof(mSendBufferBytes));
-        memcpy(mSendBufferBytes, aArgs[0].GetCString(), mSendLink.mLength);
+        mSendLink.mLength = OT_MIN(dataLen, sizeof(mSendBufferBytes));
+        memcpy(mSendBufferBytes, data, mSendLink.mLength);
 
         SuccessOrExit(error = otTcpSendByReference(&mEndpoint, &mSendLink, 0));
         mSendBusy = true;

--- a/tests/scripts/expect/cli-tcp.exp
+++ b/tests/scripts/expect/cli-tcp.exp
@@ -80,6 +80,13 @@ expect_line "Done"
 
 switch_node 1
 expect "TCP: Received 5 bytes: world"
+send "tcp send -x 546573740d0a4865780d0a\n"
+expect_line "Done"
+
+switch_node 2
+expect "TCP: Received 11 bytes: Test\r\nHex\r\n"
+
+switch_node 1
 send "tcp sendend\n"
 expect_line "Done"
 send "tcp send more\n"


### PR DESCRIPTION
…data (#11218)

This adds the `-x` flag to the `tcp send` command so send specific data defined by a hexadecimal string.  The purpose is to use this in testing, for example to emulate HTTP GET requests.

(cherry picked from commit a0243fa01a20fcc1e35db3d26f6dbc2d5a827220)