### PR TITLE
Cherry pick changes needed to add otMessageRegisterTxCallback API

### DIFF
--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -112,6 +112,15 @@ typedef struct otThreadLinkInfo
 } otThreadLinkInfo;
 
 /**
+ * Gets the `otInstance` associated with a given message.
+ *
+ * @param[in] aMessage  A message.
+ *
+ * @returns The `otInstance` associated with @p aMessage.
+ */
+otInstance *otMessageGetInstance(const otMessage *aMessage);
+
+/**
  * Free an allocated message buffer.
  *
  * @param[in]  aMessage  A pointer to a message buffer.
@@ -305,6 +314,44 @@ int8_t otMessageGetRss(const otMessage *aMessage);
  *
  */
 otError otMessageGetThreadLinkInfo(const otMessage *aMessage, otThreadLinkInfo *aLinkInfo);
+
+/**
+ * Represents the callback function pointer to notify the transmission outcome (success or failure) of a message.
+ *
+ * The error indicates the transmission status of the IPv6 message from this device to an immediate neighbor (one-hop
+ * transmission). It doesn't indicate that the message is received by its final intended destination (multi-hop away).
+ *
+ * For a unicast IPv6 message, an `OT_ERROR_NONE` error indicates that the message (all its corresponding fragment
+ * frames if the message is larger and requires fragmentation) was successfully delivered to the immediate neighbor,
+ * and a MAC layer acknowledgment was received for all fragments. This is reported regardless of whether the message
+ * is sent using direct TX or indirect TX (to a sleepy child using CSL or data poll triggered TX).
+ *
+ * For a multicast message, an `OT_ERROR_NONE` status indicates that the message (all its fragment frames) was
+ * successfully broadcast. Note that no MAC-level acknowledgment is required for broadcast frame TX.
+ *
+ * The OpenThread stack may alter the content of the message as it is prepared for transmission (e.g., IPv6 headers
+ * may be prepended, or additional metadata appended at the end). So, the content of @p aMessage when this callback
+ * is invoked may differ from its original content (e.g., when it was given as input in `otIp6Send()` for transmission).
+ *
+ * @param[in] aMessage   A pointer to the message.
+ * @param[in] aError     The TX error when sending the message.
+ * @param[in] aContext   A pointer to the user-provided context when the callback was registered.
+ */
+typedef void (*otMessageTxCallback)(const otMessage *aMessage, otError aError, void *aContext);
+
+/**
+ * Registers a callback to be notified of a message's transmission outcome.
+ *
+ * Calling this function again for the same message will replace any previously registered callback.
+ *
+ * If the message is never actually sent (e.g., it's not passed to `otIp6Send()` or other send APIs), the callback
+ * will still be invoked when the message is freed. In this case, `OT_ERROR_DROP` will be passed as the error.
+ *
+ * @param[in] aMessage   The message to register the callback with.
+ * @param[in] aCallback  The TX callback.
+ * @param[in] aContext   A pointer to a user-provided arbitrary context for the callback.
+ */
+void otMessageRegisterTxCallback(otMessage *aMessage, otMessageTxCallback aCallback, void *aContext);
 
 /**
  * Append bytes to a message.

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -40,6 +40,8 @@
 
 using namespace ot;
 
+otInstance *otMessageGetInstance(const otMessage *aMessage) { return &AsCoreType(aMessage).GetInstance(); }
+
 void otMessageFree(otMessage *aMessage) { AsCoreType(aMessage).Free(); }
 
 uint16_t otMessageGetLength(const otMessage *aMessage) { return AsCoreType(aMessage).GetLength(); }
@@ -93,6 +95,11 @@ int8_t otMessageGetRss(const otMessage *aMessage) { return AsCoreType(aMessage).
 otError otMessageGetThreadLinkInfo(const otMessage *aMessage, otThreadLinkInfo *aLinkInfo)
 {
     return AsCoreType(aMessage).GetLinkInfo(AsCoreType(aLinkInfo));
+}
+
+void otMessageRegisterTxCallback(otMessage *aMessage, otMessageTxCallback aCallback, void *aContext)
+{
+    AsCoreType(aMessage).RegisterTxCallback(aCallback, aContext);
 }
 
 otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -58,6 +58,15 @@ extern uint64_t gInstanceRaw[];
  *
  */
 
+#if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+/**
+ * Gets the single OpenThread instance.
+ *
+ * @returns The single OpenThread instance.
+ */
+inline Instance &GetSingleInstance(void) { return *reinterpret_cast<Instance *>(&gInstanceRaw); }
+#endif
+
 /**
  * Implements `Get<Type>()` method for different `Type` objects belonging to the OpenThread
  * instance.
@@ -115,7 +124,7 @@ public:
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     Instance &GetInstance(void) const { return *mInstance; }
 #else
-    Instance &GetInstance(void) const { return *reinterpret_cast<Instance *>(&gInstanceRaw); }
+    Instance &GetInstance(void) const { return GetSingleInstance(); }
 #endif
 
 protected:

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -76,7 +76,10 @@ Message *MessagePool::Allocate(Message::Type aType, uint16_t aReserveHeader, con
     VerifyOrExit((message = static_cast<Message *>(NewBuffer(aSettings.GetPriority()))) != nullptr);
 
     ClearAllBytes(*message);
-    message->SetMessagePool(this);
+
+#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+    message->GetMetadata().mInstance = &GetInstance();
+#endif
     message->SetType(aType);
     message->SetReserved(aReserveHeader);
     message->SetLinkSecurityEnabled(aSettings.IsLinkSecurityEnabled());
@@ -239,7 +242,7 @@ Error Message::ResizeMessage(uint16_t aLength)
     {
         if (curBuffer->GetNextBuffer() == nullptr)
         {
-            curBuffer->SetNextBuffer(GetMessagePool()->NewBuffer(GetPriority()));
+            curBuffer->SetNextBuffer(Get<MessagePool>().NewBuffer(GetPriority()));
             VerifyOrExit(curBuffer->GetNextBuffer() != nullptr, error = kErrorNoBufs);
         }
 
@@ -251,13 +254,13 @@ Error Message::ResizeMessage(uint16_t aLength)
     curBuffer  = curBuffer->GetNextBuffer();
     lastBuffer->SetNextBuffer(nullptr);
 
-    GetMessagePool()->FreeBuffers(curBuffer);
+    Get<MessagePool>().FreeBuffers(curBuffer);
 
 exit:
     return error;
 }
 
-void Message::Free(void) { GetMessagePool()->Free(this); }
+void Message::Free(void) { Get<MessagePool>().Free(this); }
 
 Message *Message::GetNext(void) const
 {
@@ -446,7 +449,7 @@ Error Message::PrependBytes(const void *aBuf, uint16_t aLength)
 
     while (aLength > GetReserved())
     {
-        VerifyOrExit((newBuffer = GetMessagePool()->NewBuffer(GetPriority())) != nullptr, error = kErrorNoBufs);
+        VerifyOrExit((newBuffer = Get<MessagePool>().NewBuffer(GetPriority())) != nullptr, error = kErrorNoBufs);
 
         newBuffer->SetNextBuffer(GetNextBuffer());
         SetNextBuffer(newBuffer);
@@ -788,7 +791,7 @@ Message *Message::Clone(uint16_t aLength) const
     uint16_t offset;
 
     aLength     = Min(GetLength(), aLength);
-    messageCopy = GetMessagePool()->Allocate(GetType(), GetReserved(), settings);
+    messageCopy = Get<MessagePool>().Allocate(GetType(), GetReserved(), settings);
     VerifyOrExit(messageCopy != nullptr, error = kErrorNoBufs);
     SuccessOrExit(error = messageCopy->AppendBytesFromMessage(*this, 0, aLength));
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -260,7 +260,15 @@ exit:
     return error;
 }
 
-void Message::Free(void) { Get<MessagePool>().Free(this); }
+void Message::Free(void)
+{
+    // `TxCallback` is cleared once it is invoked. If the message is
+    // freed before we know the TX outcome, it's treated as a dropped
+    // message, signaling `kErrorDrop`.
+
+    InvokeTxCallback(kErrorDrop);
+    Get<MessagePool>().Free(this);
+}
 
 Message *Message::GetNext(void) const
 {
@@ -401,6 +409,23 @@ const char *Message::PriorityToString(Priority aPriority)
     static_assert(kPriorityNet == 3, "kPriorityNet value is incorrect");
 
     return kPriorityStrings[aPriority];
+}
+
+void Message::RegisterTxCallback(TxCallback aCallback, void *aContext)
+{
+    GetMetadata().mTxCallback = aCallback;
+    GetMetadata().mTxContext  = aContext;
+}
+
+void Message::InvokeTxCallback(Error aError)
+{
+    TxCallback callback = GetMetadata().mTxCallback;
+
+    if (callback != nullptr)
+    {
+        GetMetadata().mTxCallback = nullptr;
+        callback(this, aError, GetMetadata().mTxContext);
+    }
 }
 
 Error Message::AppendBytes(const void *aBuf, uint16_t aLength)

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -217,9 +217,8 @@ protected:
         bool    mMulticastLoop : 1;       // Whether this multicast message may be looped back.
         bool    mResolvingAddress : 1;    // Whether the message is pending an address query resolution.
         bool    mAllowLookbackToHost : 1; // Whether the message is allowed to be looped back to host.
-        bool    mIsDstPanIdBroadcast : 1; // IWhether the dest PAN ID is broadcast.
-        uint8_t mOrigin : 2;
-        // The origin of the message.
+        bool    mIsDstPanIdBroadcast : 1; // Whether the dest PAN ID is broadcast.
+        uint8_t mOrigin : 2;              // The origin of the message.
 #if OPENTHREAD_CONFIG_MULTI_RADIO
         uint8_t mRadioType : 2;      // The radio link type the message was received on, or should be sent on.
         bool    mIsRadioTypeSet : 1; // Whether the radio type is set.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -188,46 +188,51 @@ public:
 protected:
     struct Metadata
     {
+        bool mDirectTx : 1;            // Whether a direct transmission is required.
+        bool mLinkSecurity : 1;        // Whether link security is enabled.
+        bool mInPriorityQ : 1;         // Whether the message is queued in normal or priority queue.
+        bool mTxSuccess : 1;           // Whether the direct tx of the message was successful.
+        bool mDoNotEvict : 1;          // Whether this message may be evicted.
+        bool mMulticastLoop : 1;       // Whether this multicast message may be looped back.
+        bool mResolvingAddress : 1;    // Whether the message is pending an address query resolution.
+        bool mAllowLookbackToHost : 1; // Whether the message is allowed to be looped back to host.
+        bool mIsDstPanIdBroadcast : 1; // Whether the dest PAN ID is broadcast.
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+        bool mIsRadioTypeSet : 1; // Whether the radio type is set.
+#endif
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+        bool mTimeSync : 1; // Whether the message is also used for time sync purpose.
+#endif
+        uint8_t mPriority : 2; // The message priority level (higher value is higher priority).
+        uint8_t mOrigin : 2;   // The origin of the message.
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+        uint8_t mRadioType : 2; // The radio link type the message was received on, or should be sent on.
+        static_assert(Mac::kNumRadioTypes <= (1 << 2), "mRadioType bitfield cannot store all radio type values");
+#endif
+        uint8_t mType : 3;    // The message type.
+        uint8_t mSubType : 4; // The message sub type.
+        uint8_t mChannel;     // The message channel (used for MLE Announce).
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+        uint8_t mTimeSyncSeq; // The time sync sequence.
+#endif
+        uint16_t mLength;      // Current message length (number of bytes).
+        uint16_t mOffset;      // A byte offset within the message.
+        uint16_t mReserved;    // Number of reserved bytes (for header).
+        uint16_t mMeshDest;    // Used for unicast non-link-local messages.
+        uint16_t mPanId;       // PAN ID (used for MLE Discover Request and Response).
+        uint32_t mDatagramTag; // The datagram tag used for 6LoWPAN frags or IPv6fragmentation.
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+        int64_t mNetworkTimeOffset; // The time offset to the Thread network time, in microseconds.
+#endif
+        TimeMilli    mTimestamp;   // The message timestamp.
         Message     *mNext;        // Next message in a doubly linked list.
         Message     *mPrev;        // Previous message in a doubly linked list.
         MessagePool *mMessagePool; // Message pool for this message.
         void        *mQueue;       // The queue where message is queued (if any). Queue type from `mInPriorityQ`.
-        uint32_t     mDatagramTag; // The datagram tag used for 6LoWPAN frags or IPv6fragmentation.
-        TimeMilli    mTimestamp;   // The message timestamp.
-        uint16_t     mReserved;    // Number of reserved bytes (for header).
-        uint16_t     mLength;      // Current message length (number of bytes).
-        uint16_t     mOffset;      // A byte offset within the message.
-        uint16_t     mMeshDest;    // Used for unicast non-link-local messages.
-        uint16_t     mPanId;       // PAN ID (used for MLE Discover Request and Response).
-        uint8_t      mChannel;     // The message channel (used for MLE Announce).
         RssAverager  mRssAverager; // The averager maintaining the received signal strength (RSS) average.
         LqiAverager  mLqiAverager; // The averager maintaining the Link quality indicator (LQI) average.
 #if OPENTHREAD_FTD
         ChildMask mChildMask; // ChildMask to indicate which sleepy children need to receive this.
-#endif
-
-        uint8_t mType : 3;                // The message type.
-        uint8_t mSubType : 4;             // The message sub type.
-        bool    mDirectTx : 1;            // Whether a direct transmission is required.
-        bool    mLinkSecurity : 1;        // Whether link security is enabled.
-        uint8_t mPriority : 2;            // The message priority level (higher value is higher priority).
-        bool    mInPriorityQ : 1;         // Whether the message is queued in normal or priority queue.
-        bool    mTxSuccess : 1;           // Whether the direct tx of the message was successful.
-        bool    mDoNotEvict : 1;          // Whether this message may be evicted.
-        bool    mMulticastLoop : 1;       // Whether this multicast message may be looped back.
-        bool    mResolvingAddress : 1;    // Whether the message is pending an address query resolution.
-        bool    mAllowLookbackToHost : 1; // Whether the message is allowed to be looped back to host.
-        bool    mIsDstPanIdBroadcast : 1; // Whether the dest PAN ID is broadcast.
-        uint8_t mOrigin : 2;              // The origin of the message.
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-        uint8_t mRadioType : 2;      // The radio link type the message was received on, or should be sent on.
-        bool    mIsRadioTypeSet : 1; // Whether the radio type is set.
-        static_assert(Mac::kNumRadioTypes <= (1 << 2), "mRadioType bitfield cannot store all radio type values");
-#endif
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-        bool    mTimeSync : 1;      // Whether the message is also used for time sync purpose.
-        int64_t mNetworkTimeOffset; // The time offset to the Thread network time, in microseconds.
-        uint8_t mTimeSyncSeq;       // The time sync sequence.
 #endif
     };
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -161,6 +161,8 @@ class Buffer : public otMessageBuffer, public LinkedListEntry<Buffer>
     friend class Message;
 
 public:
+    typedef otMessageTxCallback TxCallback; ///< Message TX callback.
+
     /**
      * Returns a pointer to the next message buffer.
      *
@@ -231,6 +233,8 @@ protected:
         Message    *mNext;        // Next message in a doubly linked list.
         Message    *mPrev;        // Previous message in a doubly linked list.
         void       *mQueue;       // The queue where message is queued (if any). Queue type from `mInPriorityQ`.
+        TxCallback  mTxCallback;  // The callback to inform message TX success or failure.
+        void       *mTxContext;   // The arbitrary context associated with `mTxCallback`.
         RssAverager mRssAverager; // The averager maintaining the received signal strength (RSS) average.
         LqiAverager mLqiAverager; // The averager maintaining the Link quality indicator (LQI) average.
 #if OPENTHREAD_FTD
@@ -599,6 +603,35 @@ public:
      *
      */
     static const char *PriorityToString(Priority aPriority);
+
+    /**
+     * Registers a callback to be notified of a message's transmission outcome.
+     *
+     * The registered `TxCallback` provides notification of the transmission status of the message from this device to
+     * an immediate neighbor (one hop). It doesn't indicate delivery to the final multi-hop destination.
+     *
+     * For unicast messages, `kErrorNone` callback error signifies successful delivery and MAC acknowledgment for all
+     * fragments of the message to an immediate neighbor, irrespective of whether direct or indirect TX is used. For
+     * multicast messages, `kErrorNone` indicates successful broadcast of all fragments. Note that no MAC-level ack
+     * is expected for broadcast frame transmissions.
+     *
+     * Only one callback can be registered per `Message`. Subsequent calls replace any existing callback. If the
+     * message is never actually sent, the callback will still be invoked when the message is freed, with `kErrorDrop`
+     * as the error.
+     *
+     * @param[in] aCallback   The `TxCallback` function to register with the message.
+     * @param[in] aContext    An arbitrary context that will be passed when @p aCallback is invoked.
+     */
+    void RegisterTxCallback(TxCallback aCallback, void *aContext);
+
+    /**
+     * Invokes the registered `TxCallback` on the `Message` with the given error status.
+     *
+     * The `TxCallback` is a one-time callback, meaning it's automatically cleared once it's invoked.
+     *
+     * @param[in] aError The error to report.
+     */
+    void InvokeTxCallback(Error aError);
 
     /**
      * Prepends bytes to the front of the message.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -188,6 +188,9 @@ public:
 protected:
     struct Metadata
     {
+#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+        Instance *mInstance;
+#endif
         bool mDirectTx : 1;            // Whether a direct transmission is required.
         bool mLinkSecurity : 1;        // Whether link security is enabled.
         bool mInPriorityQ : 1;         // Whether the message is queued in normal or priority queue.
@@ -224,13 +227,12 @@ protected:
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
         int64_t mNetworkTimeOffset; // The time offset to the Thread network time, in microseconds.
 #endif
-        TimeMilli    mTimestamp;   // The message timestamp.
-        Message     *mNext;        // Next message in a doubly linked list.
-        Message     *mPrev;        // Previous message in a doubly linked list.
-        MessagePool *mMessagePool; // Message pool for this message.
-        void        *mQueue;       // The queue where message is queued (if any). Queue type from `mInPriorityQ`.
-        RssAverager  mRssAverager; // The averager maintaining the received signal strength (RSS) average.
-        LqiAverager  mLqiAverager; // The averager maintaining the Link quality indicator (LQI) average.
+        TimeMilli   mTimestamp;   // The message timestamp.
+        Message    *mNext;        // Next message in a doubly linked list.
+        Message    *mPrev;        // Previous message in a doubly linked list.
+        void       *mQueue;       // The queue where message is queued (if any). Queue type from `mInPriorityQ`.
+        RssAverager mRssAverager; // The averager maintaining the received signal strength (RSS) average.
+        LqiAverager mLqiAverager; // The averager maintaining the Link quality indicator (LQI) average.
 #if OPENTHREAD_FTD
         ChildMask mChildMask; // ChildMask to indicate which sleepy children need to receive this.
 #endif
@@ -440,7 +442,11 @@ public:
      * @returns A reference to the `Instance`.
      *
      */
-    Instance &GetInstance(void) const;
+#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+    Instance &GetInstance(void) const { return *GetMetadata().mInstance; }
+#else
+    Instance &GetInstance(void) const { return GetSingleInstance(); }
+#endif
 
     /**
      * Frees this message buffer.
@@ -1593,9 +1599,6 @@ private:
         AsConst(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
     }
 
-    MessagePool *GetMessagePool(void) const { return GetMetadata().mMessagePool; }
-    void         SetMessagePool(MessagePool *aMessagePool) { GetMetadata().mMessagePool = aMessagePool; }
-
     bool IsInAQueue(void) const { return (GetMetadata().mQueue != nullptr); }
     void SetMessageQueue(MessageQueue *aMessageQueue);
     void SetPriorityQueue(PriorityQueue *aPriorityQueue);
@@ -1976,8 +1979,6 @@ private:
     uint16_t mNumAllocated;
     uint16_t mMaxAllocated;
 };
-
-inline Instance &Message::GetInstance(void) const { return GetMessagePool()->GetInstance(); }
 
 /**
  * @}

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -536,6 +536,8 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
             mSourceMatchController.DecrementMessageCount(aChild);
         }
 
+        message->InvokeTxCallback(txError);
+
         Get<MeshForwarder>().RemoveMessageIfNoPendingTx(*message);
     }
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1343,6 +1343,8 @@ void MeshForwarder::FinalizeMessageDirectTx(Message &aMessage, Error aError)
         break;
     }
 
+    aMessage.InvokeTxCallback(aError);
+
 exit:
     return;
 }


### PR DESCRIPTION
Cherry-pick `otMessageRegisterTxCallback` API addition, with the bump of `OPENTHREAD_API_VERSION` reverted.
Also, cherry-pick a couple of changes needed for conflict-free merge.