### PR TITLE
[nrf noup][ncp] clear tx tmestamp request

### DIFF
--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -182,6 +182,7 @@ public:
         mTxFrame802154.SetIsSecurityProcessed(false);
         mTxFrame802154.SetCsmaCaEnabled(true); // Set to true by default, only set to `false` for CSL transmission
         mTxFrame802154.SetIsHeaderUpdated(false);
+        mTxFrame802154.SetTxTimestampEnabled(false);
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
         mTxFrame802154.SetTxDelay(0);
         mTxFrame802154.SetTxDelayBaseTime(0);


### PR DESCRIPTION
Frames following tmestamped frame were also timestamped. Tx timestamp flag was not cleared as part of the Clrear command.